### PR TITLE
SOC-4586 - Fix properties used in intranet notifications

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/NotificationMessageUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/NotificationMessageUtils.java
@@ -16,7 +16,10 @@
  */
 package org.exoplatform.commons.api.notification;
 
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
+import java.lang.NumberFormatException;
 
 /**
  * Created by The eXo Platform SAS
@@ -26,18 +29,33 @@ import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
  */
 public class NotificationMessageUtils {
   private static int maxItemsInPopover = 0;
+
+  protected static final Log LOG = ExoLogger.getLogger(NotificationMessageUtils.class);
   
   public final static ArgumentLiteral<String> READ_PORPERTY = new ArgumentLiteral<String>(String.class, "read");
   
   public final static ArgumentLiteral<String> SHOW_POPOVER_PROPERTY = new ArgumentLiteral<String>(String.class, "showPopover");
   
   /**
-   * Gets the max items what configured in the properties file.
-   * @return
+   * Gets the number of notifications that are displayed in the popover list.<br/>
+   * The first time this method is called, it will retrieve it from the configuration, via the property exo.notification.maxitems,
+   * or default to 8 if the property is not set.<br/>
+   * If the property is set to an incorrect value (negative number, 0, not a number), the default value is used too.
+   * @return the number of items (notifications) that are displayed in the popover list.
    */
   public static int getMaxItemsInPopover() {
     if (maxItemsInPopover == 0) {
-      maxItemsInPopover = Integer.valueOf(System.getProperty("exo.notifications.maxitems", "8"));
+      String maxItemsProperty = System.getProperty("exo.notification.maxitems", "8");
+      try {
+        maxItemsInPopover = Integer.valueOf(maxItemsProperty);
+        if (maxItemsInPopover <= 0) {
+          LOG.warn("The value of the property exo.notification.maxitems cannot be 0 or negative. Using the default value instead: 8.");
+          maxItemsInPopover = 8;
+        }
+      } catch (NumberFormatException e) {
+        LOG.warn(String.format("The value of the property exo.notification.maxitems is incorrect: %s. Using the default value instead: 8.", maxItemsProperty));
+        maxItemsInPopover = 8;
+      }
     }
     return maxItemsInPopover;
   }

--- a/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/notification-configuration.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/notification-configuration.xml
@@ -220,7 +220,7 @@
           <property name="jobName" value="NotificationDailyJob"/>
           <property name="groupName" value="Notification"/>
           <property name="job" value="org.exoplatform.commons.notification.job.NotificationDailyJob"/>
-          <property name="expression" value="${cronJob.notification.NotificationDailyJob.expression:0 0 23 ? * *}"/><!-- Run at 11:00pm every day -->
+          <property name="expression" value="${exo.notification.NotificationDailyJob.expression:0 0 23 ? * *}"/><!-- Run at 11:00pm every day -->
         </properties-param>
       </init-params>
     </component-plugin>
@@ -240,7 +240,7 @@
           <property name="jobName" value="NotificationWeeklyJob"/>
           <property name="groupName" value="Notification"/>
           <property name="job" value="org.exoplatform.commons.notification.job.NotificationWeeklyJob"/>
-          <property name="expression" value="${cronJob.notification.NotificationWeeklyJob.expression:0 0 11 ? * SUN}"/><!-- Run at 11:00am every Sunday in every month -->
+          <property name="expression" value="${exo.notification.NotificationWeeklyJob.expression:0 0 11 ? * SUN}"/><!-- Run at 11:00am every Sunday in every month -->
         </properties-param>
       </init-params>
     </component-plugin>
@@ -260,12 +260,12 @@
 					<property name="jobName" value="WebNotificationJob" />
 					<property name="groupName" value="Notification" />
 					<property name="job" value="org.exoplatform.commons.notification.job.WebNotificationJob" />
-					<property name="expression" value="${cronJob.notification.WebNotificationJob.expression:0 0 23 ? * *}" /><!-- Run at 11:00pm every day -->
+					<property name="expression" value="${exo.notification.WebNotificationCleanJob.expression:0 0 23 ? * *}" /><!-- Run at 11:00pm every day -->
 				</properties-param>
 				<properties-param>
 					<name>web.info</name>
 					<description></description>
-					<property name="liveDays" value="${exo.notifications.viewall:2600000}" />
+					<property name="liveDays" value="${exo.notification.viewall:30}" /><!-- 30 days -->
 				</properties-param>
 			</init-params>
 		</component-plugin>


### PR DESCRIPTION
Use proper exo.notification prefix for notif properties.
Check values passed in viewall and maxitems properties.