### PR TITLE
COMMONS-407: [IE11][Document Selector] Broken encoding of Folder name

### DIFF
--- a/commons-webui-resources/src/main/webapp/javascript/eXo/commons/commons-Document.js
+++ b/commons-webui-resources/src/main/webapp/javascript/eXo/commons/commons-Document.js
@@ -199,7 +199,6 @@ DocumentSelector.prototype.renderDetailsFolder = function(documentItem) {
   url += "&" + this.isFolderOnlyParam + "=false";
   // To avoid the problem ajax caching on IE (issue: COMMONS-109)
   url += "&dummy=" + new Date().getTime();
-  url = encodeURI(url);
   var data = me.request(url);
   var folderContainer = data.getElementsByTagName("Folders")[0];
   var folderList = folderContainer.getElementsByTagName("Folder");
@@ -417,7 +416,6 @@ DocumentSelector.prototype.newFolder = function(inputFolderName){
   url += "&" + me.workspaceNameParam + "=" + workspaceName;
   url += "&" + me.currentFolderParam + "=" + me.selectedItem.currentFolder;
   url += "&" + me.folderNameParam + "=" + folderName;  
-  url = encodeURI(url);
   me.request(url);
   me.renderDetails(me.selectedItem);
 };
@@ -561,6 +559,7 @@ function BreadCrumbs() {
 
 DocumentSelector.prototype.request = function(url){
   var res;
+  url = encodeURI(url);
   jQuery.ajax({
     url: url,
     type: "GET",
@@ -805,7 +804,8 @@ function UIDSUpload() {
 	  url += "action=save" + "&workspaceName=" + selectedItem.workspaceName
 	  + "&driveName=" + selectedItem.driveName + "&currentFolder="
 	  + selectedItem.currentFolder + "&currentPortal=" + eXo.env.portal.portalName + "&language="
-	  + eXo.env.portal.language +"&uploadId=" + uploadId + "&fileName=" + encodeURIComponent(fileName);
+	  + eXo.env.portal.language +"&uploadId=" + uploadId + "&fileName=" + fileName;
+          url = encodeURI(url);
 	  var responseText = ajaxAsyncGetRequest(url, false);
 	};
 

--- a/commons-webui-resources/src/main/webapp/javascript/eXo/commons/commons-Document.js
+++ b/commons-webui-resources/src/main/webapp/javascript/eXo/commons/commons-Document.js
@@ -199,6 +199,7 @@ DocumentSelector.prototype.renderDetailsFolder = function(documentItem) {
   url += "&" + this.isFolderOnlyParam + "=false";
   // To avoid the problem ajax caching on IE (issue: COMMONS-109)
   url += "&dummy=" + new Date().getTime();
+  url = encodeURI(url);
   var data = me.request(url);
   var folderContainer = data.getElementsByTagName("Folders")[0];
   var folderList = folderContainer.getElementsByTagName("Folder");
@@ -416,6 +417,7 @@ DocumentSelector.prototype.newFolder = function(inputFolderName){
   url += "&" + me.workspaceNameParam + "=" + workspaceName;
   url += "&" + me.currentFolderParam + "=" + me.selectedItem.currentFolder;
   url += "&" + me.folderNameParam + "=" + folderName;  
+  url = encodeURI(url);
   me.request(url);
   me.renderDetails(me.selectedItem);
 };


### PR DESCRIPTION
Fix description:
- Encode URL before requesting to avoid mis-decoding in IE with accent characters