### PR TITLE
DEP-120: Implements new method BayeuxContext#getLocales

### DIFF
--- a/commons-comet-service/src/main/java/org/exoplatform/ws/frameworks/cometd/transport/ExoWebSocketTransport.java
+++ b/commons-comet-service/src/main/java/org/exoplatform/ws/frameworks/cometd/transport/ExoWebSocketTransport.java
@@ -34,10 +34,7 @@ import java.io.IOException;
 import java.net.HttpCookie;
 import java.net.InetSocketAddress;
 import java.security.Principal;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.Executor;
 
 import org.cometd.bayeux.server.BayeuxContext;
@@ -250,6 +247,8 @@ public class ExoWebSocketTransport extends AbstractWebSocketTransport<Session> {
 
     private final InetSocketAddress         remoteAddress;
 
+    private final List<Locale>              locales;
+
     private WebSocketContext(ServletContext context,
                              HandshakeRequest request,
                              Map<String, Object> userProperties) {
@@ -269,6 +268,7 @@ public class ExoWebSocketTransport extends AbstractWebSocketTransport<Session> {
       // Hopefully this will become a standard, for now it's Jetty specific.
       this.localAddress = (InetSocketAddress) userProperties.get("javax.websocket.endpoint.localAddress");
       this.remoteAddress = (InetSocketAddress) userProperties.get("javax.websocket.endpoint.remoteAddress");
+      this.locales = retrieveLocales(userProperties);
     }
 
     @Override
@@ -367,6 +367,19 @@ public class ExoWebSocketTransport extends AbstractWebSocketTransport<Session> {
     @Override
     public String getURL() {
       return url;
+    }
+
+    @Override
+    public List<Locale> getLocales() {
+      return locales;
+    }
+
+    private List<Locale> retrieveLocales(Map<String, Object> userProperties) {
+      @SuppressWarnings("unchecked")
+      List<Locale> localeList = (List<Locale>)userProperties.get("javax.websocket.locales");
+      if (localeList == null || localeList.isEmpty())
+        return Collections.singletonList(Locale.getDefault());
+      return localeList;
     }
   }
 


### PR DESCRIPTION
The CometD API has changed since version 3.0.7:

  * Issue #615 (Please expose request.getLocale() in BayeuxContext).
  * https://github.com/cometd/cometd/commit/5a288b29f1a4e7ab6ca3525f5e62f474c52826f4#diff-cb677c0cf1a1efbb735559469ee9bed8

This PR is related to the DEP-120: Upgrade org.cometd.java:* version from 3.0.5 -> 3.0.8:
* https://jira.exoplatform.org/browse/DEP-120: