### PR TITLE
PLF-6592: Improve Transparent Upgrade Plugin

### DIFF
--- a/commons-component-upgrade/pom.xml
+++ b/commons-component-upgrade/pom.xml
@@ -16,6 +16,10 @@
     <!-- This dependency is used for main classes compilation but is erroneously reported as useless by mvn dependency:analyze -->
     <dependency>
       <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-component-product</artifactId>
     </dependency>
       <dependency>

--- a/commons-component-upgrade/pom.xml
+++ b/commons-component-upgrade/pom.xml
@@ -19,10 +19,6 @@
       <artifactId>commons-component-product</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.jcr</groupId>
       <artifactId>exo.jcr.component.core</artifactId>
       <exclusions>

--- a/commons-component-upgrade/pom.xml
+++ b/commons-component-upgrade/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>commons-component-product</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.jcr</groupId>
       <artifactId>exo.jcr.component.core</artifactId>
       <exclusions>

--- a/commons-component-upgrade/pom.xml
+++ b/commons-component-upgrade/pom.xml
@@ -18,6 +18,10 @@
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-component-product</artifactId>
     </dependency>
+      <dependency>
+       <groupId>org.exoplatform.commons</groupId>
+       <artifactId>commons-api</artifactId>
+     </dependency>
     <dependency>
       <groupId>org.exoplatform.jcr</groupId>
       <artifactId>exo.jcr.component.core</artifactId>

--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
@@ -1,20 +1,18 @@
 package org.exoplatform.commons.upgrade;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.InvalidItemStateException;
-import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
-import javax.jcr.ReferentialIntegrityException;
 import javax.jcr.RepositoryException;
-import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.nodetype.NoSuchNodeTypeException;
 import javax.jcr.version.Version;
-import javax.jcr.version.VersionException;
 
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.commons.chromattic.ChromatticManager;
 import org.exoplatform.commons.info.ProductInformations;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.component.BaseComponentPlugin;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.log.ExoLogger;
@@ -22,39 +20,56 @@ import org.exoplatform.services.log.Log;
 
 public abstract class UpgradeProductPlugin extends BaseComponentPlugin implements Comparable<UpgradeProductPlugin> {
 
-  private static final Log LOG = ExoLogger.getLogger(UpgradeProductPlugin.class);
-  private static final String PRODUCT_GROUP_ID = "product.group.id";
-  private static final String OLD_PRODUCT_GROUP_ID = "old.product.group.id";
+  public static final String  UPGRADE_COMPLETED_STATUS       = "Completed";
+
+  private static final Log    LOG                            = ExoLogger.getLogger(UpgradeProductPlugin.class);
+
+  private static final String PRODUCT_GROUP_ID               = "product.group.id";
+
+  private static final String OLD_PRODUCT_GROUP_ID           = "old.product.group.id";
+
   private static final String UPGRADE_PLUGIN_EXECUTION_ORDER = "plugin.execution.order";
-  private static final String UPGRADE_PLUGIN_ENABLE = "commons.upgrade.{$0}.enable";
-  
-  private int pluginExecutionOrder;
+
+  private static final String UPGRADE_PLUGIN_ENABLE          = "commons.upgrade.{$0}.enable";
+
+  private ChromatticManager   chromatticManager;
+
+  private SettingService      settingService;
+
+  private int                 pluginExecutionOrder;
 
   /**
-   * The plugin's product maven group identifier, by example: org.exoplatform.portal for gatein.
+   * The plugin's product maven group identifier, by example:
+   * org.exoplatform.portal for gatein.
    */
-  protected String productGroupId;
-  
-  protected String oldProductGroupId;
+  protected String            productGroupId;
+
+  protected String            oldProductGroupId;
+
+  public UpgradeProductPlugin(SettingService settingService, ChromatticManager chromatticManager, InitParams initParams) {
+    this(initParams);
+    this.settingService = settingService;
+    this.chromatticManager = chromatticManager;
+  }
 
   public UpgradeProductPlugin(InitParams initParams) {
     if (!initParams.containsKey(PRODUCT_GROUP_ID)) {
-      if(LOG.isErrorEnabled()){
+      if (LOG.isErrorEnabled()) {
         LOG.error("Couldn't find the init value param: " + PRODUCT_GROUP_ID);
       }
       return;
     }
-    
+
     //
     productGroupId = initParams.getValueParam(PRODUCT_GROUP_ID).getValue();
-    
+
     //
     ValueParam vp = initParams.getValueParam(OLD_PRODUCT_GROUP_ID);
     oldProductGroupId = vp != null ? vp.getValue() : productGroupId;
-    
+
     if (!initParams.containsKey(UPGRADE_PLUGIN_EXECUTION_ORDER)) {
       pluginExecutionOrder = 0;
-    }else{
+    } else {
       pluginExecutionOrder = Integer.parseInt(initParams.getValueParam(UPGRADE_PLUGIN_EXECUTION_ORDER).getValue());
     }
   }
@@ -62,10 +77,10 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   public String getProductGroupId() {
     return productGroupId;
   }
-  
 
   /**
    * Gets old version what needs to upgrade
+   * 
    * @return
    */
   public String getOldProductGroupId() {
@@ -73,45 +88,32 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   }
 
   /**
-   * Determines if the plugin is enabled, this method will be called when adding the plugin to the upgradePlugins list.
-   * See {@link UpgradeProductService#addUpgradePlugin(UpgradeProductPlugin)}
+   * Determines if the plugin is enabled, this method will be called when adding
+   * the plugin to the upgradePlugins list. See
+   * {@link UpgradeProductService#addUpgradePlugin(UpgradeProductPlugin)}
    * 
-   * @return
-   *          true: if the plugin is enabled: should be added to the upgradePlugins list
-   *          false: if the plugin is disabled: should not be added to the upgradePlugins list
+   * @return true: if the plugin is enabled: should be added to the
+   *         upgradePlugins list false: if the plugin is disabled: should not be
+   *         added to the upgradePlugins list
    */
-  public boolean isEnabled(){
+  public boolean isEnabled() {
     String isEnabledProperty = PropertyManager.getProperty(UPGRADE_PLUGIN_ENABLE.replace("{$0}", getName()));
-    if(isEnabledProperty == null || isEnabledProperty.equals("true")){
+    if (isEnabledProperty == null || isEnabledProperty.equals("true")) {
       return true;
-    }else {
+    } else {
       return false;
     }
   }
 
   /**
+   * Add node's version with a label. The node's session have to still open, and
+   * this method don't handle the node's session closure.
    * 
-   * Add node's version with a label. The node's session have to still open, and this method don't handle
-   * the node's session closure.
-   * 
-   * @param nodeToAddVersion
-   *          the node that will be versioned
-   * @param versionLabel
-   *          the label to apply to the new created version
-   * 
-   * @throws NoSuchNodeTypeException
-   * @throws VersionException
-   * @throws ConstraintViolationException
-   * @throws LockException
-   * @throws AccessDeniedException
-   * @throws ItemExistsException
-   * @throws InvalidItemStateException
-   * @throws ReferentialIntegrityException
+   * @param nodeToAddVersion the node that will be versioned
+   * @param versionLabel the label to apply to the new created version
    * @throws RepositoryException
    */
-  public void addNodeVersion(Node nodeToAddVersion, String versionLabel) throws NoSuchNodeTypeException, VersionException,
-      ConstraintViolationException, LockException, AccessDeniedException, ItemExistsException, InvalidItemStateException,
-      ReferentialIntegrityException, RepositoryException {
+  public void addNodeVersion(Node nodeToAddVersion, String versionLabel) throws RepositoryException {
     if (!nodeToAddVersion.isNodeType(ProductInformations.MIX_VERSIONABLE)) {
       nodeToAddVersion.addMixin(ProductInformations.MIX_VERSIONABLE);
       nodeToAddVersion.save();
@@ -137,23 +139,22 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   public abstract void processUpgrade(String oldVersion, String newVersion);
 
   /**
-   * This method is called when a new version has been detected to decide whether proceed to upgrade or not.
-   * It should take care that some versions could be skipped while upgrading, i.e: the upgrade could happen 
-   * when the product is switched from version 1.0 to 1.3.
+   * This method is called when a new version has been detected to decide
+   * whether proceed to upgrade or not. It should take care that some versions
+   * could be skipped while upgrading, i.e: the upgrade could happen when the
+   * product is switched from version 1.0 to 1.3.
    * 
-   * @param previousVersion
-   *          The previous version of plugin's product
-   * @param newVersion
-   *          The previous version of plugin's product
-   * @return
-   *          true: if the plugin should be executed when switching product from previousVersion to newVersion
-   *          true: if the upgrade isn't necessary
+   * @param previousVersion The previous version of plugin's product
+   * @param newVersion The previous version of plugin's product
+   * @return true: if the plugin should be executed when switching product from
+   *         previousVersion to newVersion true: if the upgrade isn't necessary
    */
   public abstract boolean shouldProceedToUpgrade(String newVersion, String previousVersion);
 
   /**
    * {@inheritDoc}
    */
+  @Override
   public final boolean equals(Object obj) {
     if (obj != null && obj instanceof UpgradeProductPlugin) {
       return this.getName().equals(((UpgradeProductPlugin) obj).getName());
@@ -164,27 +165,66 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   /**
    * {@inheritDoc}
    */
+  @Override
   public final int hashCode() {
     return this.getName().hashCode();
   }
-  
+
   /**
    * {@inheritDoc}
    */
+  @Override
   public int compareTo(UpgradeProductPlugin o) {
-    if(this.equals(o)){
-      //doesn't allow two plugins with the same name
+    if (this.equals(o)) {
+      // doesn't allow two plugins with the same name
       return 0;
-    }else if(this.getPluginExecutionOrder() == o.getPluginExecutionOrder()){
-      //execution order doesn't matter in this case
+    } else if (this.getPluginExecutionOrder() == o.getPluginExecutionOrder()) {
+      // execution order doesn't matter in this case
       return -1;
-      }
-    //execution order will be used in the upgradePlugins' list sorting
+    }
+    // execution order will be used in the upgradePlugins' list sorting
     return (this.getPluginExecutionOrder() - o.getPluginExecutionOrder());
   }
 
   public int getPluginExecutionOrder() {
     return pluginExecutionOrder;
+  }
+
+  public String getValue(String paramName) {
+    if (chromatticManager == null) {
+      throw new IllegalStateException("ChromatticManager Service is not set");
+    }
+    if (settingService == null) {
+      throw new IllegalStateException("SettingService Service is not set");
+    }
+    RequestLifeCycle.begin(chromatticManager);
+    try {
+      Scope appId = Scope.APPLICATION.id(getName());
+      SettingValue<?> paramValue = settingService.get(Context.GLOBAL, appId, paramName);
+      if (paramValue != null && paramValue.getValue() != null) {
+        return paramValue.getValue().toString();
+      }
+      return null;
+    } finally {
+      RequestLifeCycle.end();
+      Scope.APPLICATION.id(null);
+    }
+  }
+
+  public void storeValueForPlugin(String paramName, String paramValue) {
+    if (chromatticManager == null) {
+      throw new IllegalStateException("ChromatticManager Service is not set");
+    }
+    if (settingService == null) {
+      throw new IllegalStateException("SettingService Service is not set");
+    }
+    RequestLifeCycle.begin(chromatticManager);
+    try {
+      settingService.set(Context.GLOBAL, Scope.APPLICATION.id(getName()), paramName, SettingValue.create(paramValue));
+    } finally {
+      RequestLifeCycle.end();
+      Scope.APPLICATION.id(null);
+    }
   }
 
 }

--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
@@ -34,7 +34,6 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin {
   private static final String PRODUCT_GROUP_ID = "product.group.id";
   private static final String OLD_PRODUCT_GROUP_ID = "old.product.group.id";
   private static final String UPGRADE_PLUGIN_EXECUTION_ORDER = "plugin.execution.order";
-
   private static final String UPGRADE_PLUGIN_ENABLE = "commons.upgrade.{$0}.enable";
 
   private ChromatticManager   chromatticManager;

--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
@@ -1,8 +1,16 @@
 package org.exoplatform.commons.upgrade;
 
+import javax.jcr.AccessDeniedException;
+import javax.jcr.InvalidItemStateException;
+import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
+import javax.jcr.ReferentialIntegrityException;
 import javax.jcr.RepositoryException;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
 import javax.jcr.version.Version;
+import javax.jcr.version.VersionException;
 
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
@@ -18,33 +26,30 @@ import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
-public abstract class UpgradeProductPlugin extends BaseComponentPlugin implements Comparable<UpgradeProductPlugin> {
+public abstract class UpgradeProductPlugin extends BaseComponentPlugin {
 
   public static final String  UPGRADE_COMPLETED_STATUS       = "Completed";
 
-  private static final Log    LOG                            = ExoLogger.getLogger(UpgradeProductPlugin.class);
-
-  private static final String PRODUCT_GROUP_ID               = "product.group.id";
-
-  private static final String OLD_PRODUCT_GROUP_ID           = "old.product.group.id";
-
+  private static final Log LOG = ExoLogger.getLogger(UpgradeProductPlugin.class);
+  private static final String PRODUCT_GROUP_ID = "product.group.id";
+  private static final String OLD_PRODUCT_GROUP_ID = "old.product.group.id";
   private static final String UPGRADE_PLUGIN_EXECUTION_ORDER = "plugin.execution.order";
 
-  private static final String UPGRADE_PLUGIN_ENABLE          = "commons.upgrade.{$0}.enable";
+  private static final String UPGRADE_PLUGIN_ENABLE = "commons.upgrade.{$0}.enable";
 
   private ChromatticManager   chromatticManager;
 
   private SettingService      settingService;
 
-  private int                 pluginExecutionOrder;
+  private int pluginExecutionOrder;
 
   /**
-   * The plugin's product maven group identifier, by example:
-   * org.exoplatform.portal for gatein.
+   * The plugin's product maven group identifier, by example: org.exoplatform.portal for gatein.
    */
-  protected String            productGroupId;
+  protected String productGroupId;
+  
+  protected String oldProductGroupId;
 
-  protected String            oldProductGroupId;
 
   public UpgradeProductPlugin(SettingService settingService, ChromatticManager chromatticManager, InitParams initParams) {
     this(initParams);
@@ -54,22 +59,22 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
 
   public UpgradeProductPlugin(InitParams initParams) {
     if (!initParams.containsKey(PRODUCT_GROUP_ID)) {
-      if (LOG.isErrorEnabled()) {
+      if(LOG.isErrorEnabled()){
         LOG.error("Couldn't find the init value param: " + PRODUCT_GROUP_ID);
       }
       return;
     }
-
+    
     //
     productGroupId = initParams.getValueParam(PRODUCT_GROUP_ID).getValue();
-
+    
     //
     ValueParam vp = initParams.getValueParam(OLD_PRODUCT_GROUP_ID);
     oldProductGroupId = vp != null ? vp.getValue() : productGroupId;
-
+    
     if (!initParams.containsKey(UPGRADE_PLUGIN_EXECUTION_ORDER)) {
       pluginExecutionOrder = 0;
-    } else {
+    }else{
       pluginExecutionOrder = Integer.parseInt(initParams.getValueParam(UPGRADE_PLUGIN_EXECUTION_ORDER).getValue());
     }
   }
@@ -77,10 +82,10 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   public String getProductGroupId() {
     return productGroupId;
   }
+  
 
   /**
    * Gets old version what needs to upgrade
-   * 
    * @return
    */
   public String getOldProductGroupId() {
@@ -88,32 +93,45 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   }
 
   /**
-   * Determines if the plugin is enabled, this method will be called when adding
-   * the plugin to the upgradePlugins list. See
-   * {@link UpgradeProductService#addUpgradePlugin(UpgradeProductPlugin)}
+   * Determines if the plugin is enabled, this method will be called when adding the plugin to the upgradePlugins list.
+   * See {@link UpgradeProductService#addUpgradePlugin(UpgradeProductPlugin)}
    * 
-   * @return true: if the plugin is enabled: should be added to the
-   *         upgradePlugins list false: if the plugin is disabled: should not be
-   *         added to the upgradePlugins list
+   * @return
+   *          true: if the plugin is enabled: should be added to the upgradePlugins list
+   *          false: if the plugin is disabled: should not be added to the upgradePlugins list
    */
-  public boolean isEnabled() {
+  public boolean isEnabled(){
     String isEnabledProperty = PropertyManager.getProperty(UPGRADE_PLUGIN_ENABLE.replace("{$0}", getName()));
-    if (isEnabledProperty == null || isEnabledProperty.equals("true")) {
+    if(isEnabledProperty == null || isEnabledProperty.equals("true")){
       return true;
-    } else {
+    }else {
       return false;
     }
   }
 
   /**
-   * Add node's version with a label. The node's session have to still open, and
-   * this method don't handle the node's session closure.
    * 
-   * @param nodeToAddVersion the node that will be versioned
-   * @param versionLabel the label to apply to the new created version
+   * Add node's version with a label. The node's session have to still open, and this method don't handle
+   * the node's session closure.
+   * 
+   * @param nodeToAddVersion
+   *          the node that will be versioned
+   * @param versionLabel
+   *          the label to apply to the new created version
+   * 
+   * @throws NoSuchNodeTypeException
+   * @throws VersionException
+   * @throws ConstraintViolationException
+   * @throws LockException
+   * @throws AccessDeniedException
+   * @throws ItemExistsException
+   * @throws InvalidItemStateException
+   * @throws ReferentialIntegrityException
    * @throws RepositoryException
    */
-  public void addNodeVersion(Node nodeToAddVersion, String versionLabel) throws RepositoryException {
+  public void addNodeVersion(Node nodeToAddVersion, String versionLabel) throws NoSuchNodeTypeException, VersionException,
+      ConstraintViolationException, LockException, AccessDeniedException, ItemExistsException, InvalidItemStateException,
+      ReferentialIntegrityException, RepositoryException {
     if (!nodeToAddVersion.isNodeType(ProductInformations.MIX_VERSIONABLE)) {
       nodeToAddVersion.addMixin(ProductInformations.MIX_VERSIONABLE);
       nodeToAddVersion.save();
@@ -139,22 +157,23 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   public abstract void processUpgrade(String oldVersion, String newVersion);
 
   /**
-   * This method is called when a new version has been detected to decide
-   * whether proceed to upgrade or not. It should take care that some versions
-   * could be skipped while upgrading, i.e: the upgrade could happen when the
-   * product is switched from version 1.0 to 1.3.
+   * This method is called when a new version has been detected to decide whether proceed to upgrade or not.
+   * It should take care that some versions could be skipped while upgrading, i.e: the upgrade could happen 
+   * when the product is switched from version 1.0 to 1.3.
    * 
-   * @param previousVersion The previous version of plugin's product
-   * @param newVersion The previous version of plugin's product
-   * @return true: if the plugin should be executed when switching product from
-   *         previousVersion to newVersion true: if the upgrade isn't necessary
+   * @param previousVersion
+   *          The previous version of plugin's product
+   * @param newVersion
+   *          The previous version of plugin's product
+   * @return
+   *          true: if the plugin should be executed when switching product from previousVersion to newVersion
+   *          true: if the upgrade isn't necessary
    */
   public abstract boolean shouldProceedToUpgrade(String newVersion, String previousVersion);
 
   /**
    * {@inheritDoc}
    */
-  @Override
   public final boolean equals(Object obj) {
     if (obj != null && obj instanceof UpgradeProductPlugin) {
       return this.getName().equals(((UpgradeProductPlugin) obj).getName());
@@ -165,25 +184,8 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin implement
   /**
    * {@inheritDoc}
    */
-  @Override
   public final int hashCode() {
     return this.getName().hashCode();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public int compareTo(UpgradeProductPlugin o) {
-    if (this.equals(o)) {
-      // doesn't allow two plugins with the same name
-      return 0;
-    } else if (this.getPluginExecutionOrder() == o.getPluginExecutionOrder()) {
-      // execution order doesn't matter in this case
-      return -1;
-    }
-    // execution order will be used in the upgradePlugins' list sorting
-    return (this.getPluginExecutionOrder() - o.getPluginExecutionOrder());
   }
 
   public int getPluginExecutionOrder() {

--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductPlugin.java
@@ -16,11 +16,9 @@ import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
-import org.exoplatform.commons.chromattic.ChromatticManager;
 import org.exoplatform.commons.info.ProductInformations;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.component.BaseComponentPlugin;
-import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.log.ExoLogger;
@@ -36,8 +34,6 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin {
   private static final String UPGRADE_PLUGIN_EXECUTION_ORDER = "plugin.execution.order";
   private static final String UPGRADE_PLUGIN_ENABLE = "commons.upgrade.{$0}.enable";
 
-  private ChromatticManager   chromatticManager;
-
   private SettingService      settingService;
 
   private int pluginExecutionOrder;
@@ -50,10 +46,9 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin {
   protected String oldProductGroupId;
 
 
-  public UpgradeProductPlugin(SettingService settingService, ChromatticManager chromatticManager, InitParams initParams) {
+  public UpgradeProductPlugin(SettingService settingService, InitParams initParams) {
     this(initParams);
     this.settingService = settingService;
-    this.chromatticManager = chromatticManager;
   }
 
   public UpgradeProductPlugin(InitParams initParams) {
@@ -192,13 +187,9 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin {
   }
 
   public String getValue(String paramName) {
-    if (chromatticManager == null) {
-      throw new IllegalStateException("ChromatticManager Service is not set");
-    }
     if (settingService == null) {
       throw new IllegalStateException("SettingService Service is not set");
     }
-    RequestLifeCycle.begin(chromatticManager);
     try {
       Scope appId = Scope.APPLICATION.id(getName());
       SettingValue<?> paramValue = settingService.get(Context.GLOBAL, appId, paramName);
@@ -207,23 +198,17 @@ public abstract class UpgradeProductPlugin extends BaseComponentPlugin {
       }
       return null;
     } finally {
-      RequestLifeCycle.end();
       Scope.APPLICATION.id(null);
     }
   }
 
   public void storeValueForPlugin(String paramName, String paramValue) {
-    if (chromatticManager == null) {
-      throw new IllegalStateException("ChromatticManager Service is not set");
-    }
     if (settingService == null) {
       throw new IllegalStateException("SettingService Service is not set");
     }
-    RequestLifeCycle.begin(chromatticManager);
     try {
       settingService.set(Context.GLOBAL, Scope.APPLICATION.id(getName()), paramName, SettingValue.create(paramValue));
     } finally {
-      RequestLifeCycle.end();
       Scope.APPLICATION.id(null);
     }
   }

--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductService.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductService.java
@@ -104,11 +104,13 @@ public class UpgradeProductService implements Startable {
     if (productInformations.isFirstRun()) {
       LOG.info("Proceed upgrade on first run = {}", proceedUpgradeFirstRun);
 
+      // If first run of upgrade API, and if disabled on first run, ignore plugins
       if (!proceedUpgradeFirstRun) {
         LOG.info("Ignore all upgrade plugins");
         return;
       }
 
+      // If first run, set previous version to 0
       productInformations.setPreviousVersionsIfFirstRun(PRODUCT_VERSION_ZERO);
     }
 
@@ -121,26 +123,23 @@ public class UpgradeProductService implements Startable {
     // the upgradePlugins list, execute these remaining plugins.
     for (int i = 0; i < upgradePlugins.size(); i++) {
       UpgradeProductPlugin upgradeProductPlugin = upgradePlugins.get(i);
-      String previousUpgradePluginVersion = getPreviousVersion(upgradeProductPlugin);
-      String currentUpgradePluginVersion = getCurrentVersion(upgradeProductPlugin);
+      String previousProductPluginVersion = getPreviousVersion(upgradeProductPlugin);
+      String currentProductPluginVersion = getCurrentVersion(upgradeProductPlugin);
 
       // The plugin will determine if it should proceed to upgrade
-      if (upgradeProductPlugin.shouldProceedToUpgrade(currentUpgradePluginVersion, previousUpgradePluginVersion)) {
+      if (upgradeProductPlugin.shouldProceedToUpgrade(currentProductPluginVersion, previousProductPluginVersion)) {
         LOG.info("Proceed upgrade plugin: name = " + upgradeProductPlugin.getName() + " from version "
-            + previousUpgradePluginVersion + " to " + currentUpgradePluginVersion);
+            + previousProductPluginVersion + " to " + currentProductPluginVersion);
         // Product upgrade plugin
-        upgradeProductPlugin.processUpgrade(previousUpgradePluginVersion, currentUpgradePluginVersion);
+        upgradeProductPlugin.processUpgrade(previousProductPluginVersion, currentProductPluginVersion);
         LOG.info("Upgrade " + upgradeProductPlugin.getName() + " completed.");
       } else {
         LOG.info("Ignore upgrade plugin {} from version {} to {}",
                  upgradeProductPlugin.getName(),
-                 previousUpgradePluginVersion,
-                 currentUpgradePluginVersion);
+                 previousProductPluginVersion,
+                 currentProductPluginVersion);
       }
     }
-
-    // The product has been upgraded, change the product version in the JCR
-    productInformations.storeProductsInformationsInJCR();
 
     LOG.info("Version upgrade completed.");
   }

--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductService.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/upgrade/UpgradeProductService.java
@@ -141,6 +141,8 @@ public class UpgradeProductService implements Startable {
       }
     }
 
+    productInformations.storeProductsInformationsInJCR();
+
     LOG.info("Version upgrade completed.");
   }
 

--- a/commons-component-upgrade/src/test/resources/conf/portal/test-configuration.xml
+++ b/commons-component-upgrade/src/test/resources/conf/portal/test-configuration.xml
@@ -53,6 +53,51 @@
 		</init-params>
 	</component>
 
+	<component>
+		<key>org.exoplatform.commons.api.event.EventManager</key>
+		<type>org.exoplatform.commons.event.impl.EventManagerImpl</type>
+	</component>
+	<component>
+		<key>org.exoplatform.commons.chromattic.ChromatticManager</key>
+		<type>org.exoplatform.commons.chromattic.ChromatticManager</type>
+	</component>
+
+	<component>
+		<key>org.exoplatform.settings.impl.SettingServiceImpl</key>
+		<type>org.exoplatform.settings.impl.SettingServiceImpl</type>
+	</component>
+
+	<component>
+		<key>org.exoplatform.commons.api.settings.SettingService</key>
+		<type>org.exoplatform.settings.cache.CacheSettingServiceImpl</type>
+	</component>
+	<external-component-plugins>
+		<target-component>org.exoplatform.commons.chromattic.ChromatticManager</target-component>
+		<component-plugin>
+			<name>chromattic</name>
+			<set-method>addLifeCycle</set-method>
+			<type>org.exoplatform.commons.chromattic.ChromatticLifeCycle</type>
+			<init-params>
+				<value-param>
+					<name>domain-name</name>
+					<value>setting</value>
+				</value-param>
+				<value-param>
+					<name>workspace-name</name>
+					<value>portal-test</value>
+				</value-param>
+				<values-param>
+					<name>entities</name>
+					<value>org.exoplatform.settings.chromattic.SettingsRoot</value>
+					<value>org.exoplatform.settings.chromattic.ContextEntity</value>
+					<value>org.exoplatform.settings.chromattic.SimpleContextEntity</value>
+					<value>org.exoplatform.settings.chromattic.SubContextEntity</value>
+					<value>org.exoplatform.settings.chromattic.ScopeEntity</value>
+				</values-param>
+			</init-params>
+		</component-plugin>
+	</external-component-plugins>
+
 	<!-- Add upgrade plugins to UpgradeProductService: UpgradeProductTest -->
 
 	<!-- Upgrade plugin for Portal: Only upgrade if previous version is 0 -->


### PR DESCRIPTION
Modify Transparent Upgrade Plugin to continue migration if interrupted.
In fact, each upgrade Plugin should use "storeValueForPlugin" method to store the status of plugin migration. The method "getValue" should be used in "shouldProceedToUpgrade" to determine if the migration is finished or not.
This modification is mainly used for upgrade Plugin of SOC-5286.