### PR TITLE
COMMONS-499 : clear persistence context regurlaly + execute a reindexation operation in a transaction

### DIFF
--- a/commons-search/src/test/java/org/exoplatform/addons/es/index/ElasticOperationProcessorTest.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/index/ElasticOperationProcessorTest.java
@@ -25,6 +25,7 @@ import org.exoplatform.addons.es.domain.IndexingOperation;
 import org.exoplatform.addons.es.domain.OperationType;
 import org.exoplatform.addons.es.index.impl.ElasticIndexingOperationProcessor;
 import org.exoplatform.addons.es.index.impl.ElasticIndexingServiceConnector;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,10 +72,14 @@ public class ElasticOperationProcessorTest {
   @Mock
   private ElasticContentRequestBuilder elasticContentRequestBuilder;
 
+  private EntityManagerService entityManagerService;
+
   @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
-    elasticIndexingOperationProcessor = new ElasticIndexingOperationProcessor(indexingOperationDAO, elasticIndexingClient, elasticContentRequestBuilder, auditTrail, null);
+    entityManagerService = new EntityManagerService();
+    entityManagerService.startRequest(null);
+    elasticIndexingOperationProcessor = new ElasticIndexingOperationProcessor(indexingOperationDAO, elasticIndexingClient, elasticContentRequestBuilder, auditTrail, entityManagerService, null);
     initElasticServiceConnector();
   }
 
@@ -88,6 +93,7 @@ public class ElasticOperationProcessorTest {
   @After
   public void clean() {
     elasticIndexingOperationProcessor.getConnectors().clear();
+    entityManagerService.endRequest(null);
   }
 
   /*

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/PermissionsFilterIntTest.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/PermissionsFilterIntTest.java
@@ -17,15 +17,13 @@ import org.exoplatform.addons.es.index.impl.ElasticIndexingOperationProcessor;
 import org.exoplatform.addons.es.index.impl.ElasticIndexingServiceConnector;
 import org.exoplatform.addons.es.search.ElasticSearchServiceConnector;
 import org.exoplatform.commons.api.search.data.SearchResult;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -55,6 +53,8 @@ public class PermissionsFilterIntTest extends BaseIntegrationTest {
   private ElasticSearchServiceConnector elasticSearchServiceConnector;
 
   private IndexingOperationDAO            dao;
+
+  private EntityManagerService entityManagerService;
 
   private ElasticIndexingServiceConnector wikiConnector;
 
@@ -94,12 +94,19 @@ public class PermissionsFilterIntTest extends BaseIntegrationTest {
     // IndexService
     dao = new IndexingOperationDAOImpl();
     ElasticContentRequestBuilder builder = new ElasticContentRequestBuilder();
-    indexingOperationProcessor = new ElasticIndexingOperationProcessor(dao, elasticIndexingClient, builder, new ElasticIndexingAuditTrail(), null);
+    entityManagerService = new EntityManagerService();
+    entityManagerService.startRequest(null);
+    indexingOperationProcessor = new ElasticIndexingOperationProcessor(dao, elasticIndexingClient, builder, new ElasticIndexingAuditTrail(), entityManagerService, null);
     indexingOperationProcessor.addConnector(wikiConnector);
     indexingOperationProcessor.start();
 
     // Search connector
     elasticSearchServiceConnector = new ElasticSearchServiceConnector(getInitConnectorParams(), elasticSearchingClient);
+  }
+
+  @After
+  public void tearDown() {
+    entityManagerService.endRequest(null);
   }
 
   private void setCurrentIdentity(String userId, String... memberships) {

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/SiteFilterIntTest.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/SiteFilterIntTest.java
@@ -34,6 +34,7 @@ import org.exoplatform.addons.es.index.impl.ElasticIndexingOperationProcessor;
 import org.exoplatform.addons.es.index.impl.ElasticIndexingServiceConnector;
 import org.exoplatform.addons.es.search.ElasticSearchServiceConnector;
 import org.exoplatform.commons.api.search.data.SearchResult;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
 import org.exoplatform.services.security.ConversationState;
@@ -67,6 +68,7 @@ public class SiteFilterIntTest extends BaseIntegrationTest {
   private IndexingOperationProcessor indexingOperationProcessor;
   private ElasticSearchServiceConnector elasticSearchServiceConnector;
   private IndexingOperationDAO dao;
+  private EntityManagerService entityManagerService;
   private ElasticIndexingServiceConnector testConnector;
 
   @BeforeClass
@@ -105,7 +107,9 @@ public class SiteFilterIntTest extends BaseIntegrationTest {
     //IndexService
     dao = new IndexingOperationDAOImpl();
     ElasticContentRequestBuilder builder = new ElasticContentRequestBuilder();
-    indexingOperationProcessor = new ElasticIndexingOperationProcessor(dao, elasticIndexingClient, builder, new ElasticIndexingAuditTrail(), null);
+    entityManagerService = new EntityManagerService();
+    entityManagerService.startRequest(null);
+    indexingOperationProcessor = new ElasticIndexingOperationProcessor(dao, elasticIndexingClient, builder, new ElasticIndexingAuditTrail(), entityManagerService, null);
     indexingOperationProcessor.addConnector(testConnector);
 
     //Search connector
@@ -113,6 +117,11 @@ public class SiteFilterIntTest extends BaseIntegrationTest {
 
     //Set identity
     setCurrentIdentity(USERNAME);
+  }
+
+  @After
+  public void tearDown() {
+    entityManagerService.endRequest(null);
   }
 
   private void setCurrentIdentity(String userId, String... memberships) {


### PR DESCRIPTION
This PR :
* clear the persistence context regurlaly. Each time a job is executed, the RequestLicycle is started, so an entity manager is created. It means that 1 entity manager is created for the whole job execution. To avoid having a too big persistence context and performance problems, entities are cleared when possible.
* execute the reindexation of an entity type (delete the reindexation operation row and insert a creation operation per document to index) operation in a transaction.