### PR TITLE
COMMONS-501: Improve Unit test for reindexing and deleting operations on ES

### DIFF
--- a/commons-search/pom.xml
+++ b/commons-search/pom.xml
@@ -130,6 +130,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.elasticsearch.plugin</groupId>
+        <artifactId>delete-by-query</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
       <scope>test</scope>

--- a/commons-search/pom.xml
+++ b/commons-search/pom.xml
@@ -130,11 +130,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.elasticsearch.plugin</groupId>
-        <artifactId>delete-by-query</artifactId>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
       <scope>test</scope>

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingAttachmentIntegrationTest.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingAttachmentIntegrationTest.java
@@ -99,6 +99,34 @@ public class ElasticIndexingAttachmentIntegrationTest extends BaseIntegrationTes
   }
 
   @Test
+  public void testDeleteAllDocuments() {
+    //Given
+    elasticIndexingClient.sendCreateIndexRequest("test", "");
+    elasticIndexingClient.sendCreateTypeRequest("test", "attachment", getAttachmentMapping());
+    assertEquals(0, documentNumber());
+    String bulkRequest = "{ \"create\" : { \"_index\" : \"test\", \"_type\" : \"attachment\", \"_id\" : \"1\" } }\n" +
+        "{ " +
+        "\"title\" : \"Sample CV in English\"," +
+        "\"file\" : \"" + new String(Base64.encodeBase64(MC23Quotes.getBytes())) + "\"" +
+        " }\n";
+
+    //When
+    elasticIndexingClient.sendCUDRequest(bulkRequest);
+
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    elasticIndexingClient.sendDeleteAllDocsOfTypeRequest("test", "attachment");
+    node.client().admin().indices().prepareRefresh().execute().actionGet();
+
+    // Then
+    assertEquals(0, documentNumber());
+  }
+
+  @Test
   public void testSearchAttachment() {
     //Given
     elasticIndexingClient.sendCreateIndexRequest("test", "");

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingAttachmentIntegrationTest.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingAttachmentIntegrationTest.java
@@ -113,11 +113,7 @@ public class ElasticIndexingAttachmentIntegrationTest extends BaseIntegrationTes
     //When
     elasticIndexingClient.sendCUDRequest(bulkRequest);
 
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
+    node.client().admin().indices().prepareRefresh().execute().actionGet();
 
     elasticIndexingClient.sendDeleteAllDocsOfTypeRequest("test", "attachment");
     node.client().admin().indices().prepareRefresh().execute().actionGet();


### PR DESCRIPTION
This PR will add a Unit test to test if the "DeleteAll" operation works with the used version of ES.
The ES plugin "Delete by Query" is mandatory and should be added in documentation.