### PR TITLE
Run Integration Tests interacting with Elastisearch in the integration-test maven phase

### DIFF
--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/BaseElasticsearchIT.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/BaseElasticsearchIT.java
@@ -59,8 +59,8 @@ import org.junit.BeforeClass;
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com
  * 10/1/15
  */
-public class BaseESIntegrationTest {
-  private static final Log LOGGER = ExoLogger.getExoLogger(BaseESIntegrationTest.class);
+public class BaseElasticsearchIT {
+  private static final Log LOGGER = ExoLogger.getExoLogger(BaseElasticsearchIT.class);
   protected static Node node;
 
   private static boolean propertiesSet;

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingAttachmentIT.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingAttachmentIT.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
 /**
  *
  */
-public class ElasticIndexingAttachmentIntegrationTest extends BaseESIntegrationTest {
+public class ElasticIndexingAttachmentIT extends BaseElasticsearchIT {
 
   private final static String MC23Quotes =
       "Some people want it to happen, some wish it would happen, others make it happen.";

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingIT.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticIndexingIT.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutionException;
  * tclement@exoplatform.com
  * 8/20/15
  */
-public class ElasticIndexingIntegrationTest extends BaseESIntegrationTest {
+public class ElasticIndexingIT extends BaseElasticsearchIT {
 
   @Test
   public void testCreateNewIndex() throws ExecutionException, InterruptedException {

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticSearchingIT.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/ElasticSearchingIT.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
  * Created by The eXo Platform SAS Author : Thibault Clement
  * tclement@exoplatform.com 9/11/15
  */
-public class ElasticSearchingIntegrationTest extends BaseESIntegrationTest {
+public class ElasticSearchingIT extends BaseElasticsearchIT {
 
   ElasticSearchServiceConnector elasticSearchServiceConnector;
 

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/PermissionsFilterIT.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/PermissionsFilterIT.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com
  * 9/9/15
  */
-public class PermissionsFilterIntTest extends BaseESIntegrationTest {
+public class PermissionsFilterIT extends BaseElasticsearchIT {
   private static Connection               conn;
 
   private static Liquibase                liquibase;

--- a/commons-search/src/test/java/org/exoplatform/addons/es/integration/SiteFilterIT.java
+++ b/commons-search/src/test/java/org/exoplatform/addons/es/integration/SiteFilterIT.java
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.when;
  * tclement@exoplatform.com
  * 10/2/15
  */
-public class SiteFilterIntTest extends BaseESIntegrationTest {
+public class SiteFilterIT extends BaseElasticsearchIT {
 
   private static final String USERNAME = "thib";
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
     <!-- **************************************** -->
     <jenkins.job.name>commons-master-ci</jenkins.job.name>
     <!-- **************************************** -->
+    <!-- Build Settings                           -->
+    <!-- **************************************** -->
+    <skipTests>false</skipTests>
+    <skipUTests>${skipTests}</skipUTests>
+    <skipITests>${skipTests}</skipITests>
+    <!-- **************************************** -->
     <!-- Dependencies versions                    -->
     <!-- **************************************** -->
     <org.exoplatform.depmgt.version>12-SNAPSHOT</org.exoplatform.depmgt.version>
@@ -325,6 +331,20 @@
           <configuration>
             <!-- Don't include libraries into Web Archives -->
             <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <skipTests>${skipUTests}</skipTests>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <skipTests>${skipITests}</skipTests>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
The Integration Tests can now be run with the profile run-its and are not run by default.
Also, I added new variables to skip tests (skipTests, skipUTests, skipITests). I added them in the commons project pom. WDYT ? Do we keep them ? If yes, shoudn't it be moved to the parent pom instead ?