### PR TITLE
PLF-6814: Load groovy templates in parallel as the server starts up

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/cache/TemplateCachePopulator.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/cache/TemplateCachePopulator.java
@@ -1,0 +1,72 @@
+package org.exoplatform.commons.cache;
+
+import java.util.List;
+
+import org.picocontainer.Startable;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValuesParam;
+import org.exoplatform.groovyscript.text.TemplateService;
+import org.exoplatform.resolver.ApplicationResourceResolver;
+import org.exoplatform.resolver.ServletResourceResolver;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+public class TemplateCachePopulator implements Startable {
+  private static final Log    LOG = ExoLogger.getLogger(TemplateCachePopulator.class);
+
+  TemplateService             templateService;
+
+  ApplicationResourceResolver resolver;
+
+  List<String>                templates;
+
+  PortalContainer container;
+
+  public TemplateCachePopulator(TemplateService templateService, PortalContainer container, InitParams initParams) {
+    this.templateService = templateService;
+    this.container = container;
+    resolver = new ApplicationResourceResolver();
+    resolver.addResourceResolver(new ServletResourceResolver(container.getPortalContext(), "war:"));
+    resolver.addResourceResolver(new ServletResourceResolver(container.getPortalContext(), "app:"));
+    resolver.addResourceResolver(new ServletResourceResolver(container.getPortalContext(), "system:"));
+    resolver.addResourceResolver(new ServletResourceResolver(container.getPortalContext().getContext("/eXoResources"),
+                                                             "resources:"));
+    ValuesParam valuesParam = initParams.getValuesParam("templates");
+    if(valuesParam != null) {
+      templates = valuesParam.getValues();
+    }
+
+    init();
+  }
+
+  private void init() {
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        if (templates != null && !templates.isEmpty()) {
+          Thread.currentThread().setContextClassLoader(container.getPortalClassLoader());
+          LOG.info("Start caching templates");
+          long started = System.currentTimeMillis();
+          for (String templateId : templates) {
+            try {
+              LOG.debug("Cache template {}", templateId);
+              templateService.getTemplate(templateId, resolver, true);
+            } catch (Exception e) {
+              LOG.debug("Error cache template {}, cause = {}", templateId, e.getMessage());
+            }
+          }
+          long end = System.currentTimeMillis();
+          long timeSpent = (end - started) / 1000;
+          LOG.info("Templates cached in {} seconds", timeSpent);
+        }
+      }
+    }).start();
+  }
+  
+  public void start() {}
+
+  public void stop() {}
+
+}


### PR DESCRIPTION
The groovy templates decreases the whole first user experience with the platform because it takes so much time to be loaded on first login.
In this, task, we will add a new Service that loads in parallel the templates while the server continue to startup.