### PR TITLE
PLF-6911 User should add https:// when writing an URL to add a link in microblog

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/simpleLink/dialogs/simpleLink.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/simpleLink/dialogs/simpleLink.js
@@ -29,7 +29,11 @@ CKEDITOR.dialog.add( 'simpleLinkDialog', function( editor ) {
                             this.setValue(element.getAttribute("href") );
                         },
                         commit: function(element) {
-                            element.setAttribute("href", this.getValue());
+                            var url = this.getValue();
+                            if (url && !url.match(/^(\/|((https?|ftp|file):\/\/))/ig)) {
+                                url = "http://" + url;
+                            }
+                            element.setAttribute("href", url);
                         }
                     }
                 ]


### PR DESCRIPTION
We auto prepent http:// into URL if user does not inputs an absolute uri (in platform) or a full url