### PR TITLE
PLF-6923 [Formatting TXT] Cannot paste a text from a word .doc

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -43,6 +43,7 @@
 				(function() {
 				var oldJQuery = window.jQuery;
 				window.jQuery = $;
+				window.CKEDITOR_BASEPATH = '/commons-extension/ckeditor/';
 				<include>/ckeditor/ckeditor.js</include>
 				<include>/ckeditor/adapters/jquery.js</include>
 				<include>/ckeditor/lang/en.js</include>


### PR DESCRIPTION
By default, the basePath of ckeditor is empty, it raise the wrong path in build-in plugins (like paste, pastefromwork, clipboard - they are included in minify version of ckeditor.js) when they define the path of filter, dialog.

The solution: configure the basePath of ckeditor before load.