### PR TITLE
WIKI-1354 : allow rel attribute in HTML links in HTML sanitizer

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -128,7 +128,7 @@ abstract public class HTMLSanitizer {
                                                                                                                                 .allowStandardUrlProtocols()
                                                                                                                                 .allowAttributes("nohref")
                                                                                                                                 .onElements("a")
-                                                                                                                                .allowAttributes("name")
+                                                                                                                                .allowAttributes("name", "rel")
                                                                                                                                 .matching(NAME)
                                                                                                                                 .onElements("a")
                                                                                                                                 .allowAttributes("onfocus",


### PR DESCRIPTION
XWiki uses rel attribute in "a" tag to pass the target, but this attribute is sanitized by the HTML sanitizer. This PR allows this attribute.
There is one issue about this solution. The sanitizer forces the addition of the rel attribute with the value "nofollow" (https://github.com/exodev/commons/blob/develop/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java#L141). So now when a rel attribute already exists on the tag, there are 2 rel attributes after the sanitizations. In the case of wiki pages the browser takes only the first one, which is the one added in xwiki syntax, so the functional issue is fixed, but the nofollow is ignored.
One solution is to upgrade the lib owasp-java-html-sanitizer since it supports multiple values in the rel attribute in its last versions, but I think it must be done in a dedicated issue since it can have side effects. So the current solution is acceptable enough IMO.