### PR TITLE
PLF-7930 : manage the case of mimeType attribute is null when filtering UIExtension

### DIFF
--- a/commons-webui-ext/src/main/java/org/exoplatform/webui/ext/filter/impl/FileFilter.java
+++ b/commons-webui-ext/src/main/java/org/exoplatform/webui/ext/filter/impl/FileFilter.java
@@ -37,8 +37,10 @@ public class FileFilter implements UIExtensionFilter {
     if (mimeTypes == null || mimeTypes.isEmpty()) {
       return true;
     }
-    String mimeType = context.get("mimeType").toString();
-    if(mimeTypes.contains(mimeType)) return true;
+    if(context != null && context.containsKey("mimeType")) {
+      Object mimeType = context.get("mimeType");
+      return mimeType != null && mimeTypes.contains(mimeType.toString());
+    }
     return false;
   }
 

--- a/commons-webui-ext/src/test/java/org/exoplatform/webui/ext/filter/impl/FileFilterTest.java
+++ b/commons-webui-ext/src/test/java/org/exoplatform/webui/ext/filter/impl/FileFilterTest.java
@@ -43,17 +43,17 @@ public class FileFilterTest extends TestCase {
    * Case 01: when the mimetypes attribute of FileFilter is null
    * Expected result: return TRUE
    */
-  public void testAcceptWhenMimeTypeNull() {
+  public void testAcceptWhenAllMimeTypesAllowed() throws Exception {
+    // Given
     FileFilter filter = new FileFilterDummy();
     Map<String, Object> context = new HashMap<String, Object>();
     context.put("mimeType", "application/pdf");
 
-    try {
-      boolean isAccepted = filter.accept(context);
-      assertEquals(isAccepted, true);
-    } catch (Exception ex) {
-      Assert.fail("testAcceptWhenMimeTypeNull is FAILED because of an unhandled excaption");
-    }
+    // When
+    boolean isAccepted = filter.accept(context);
+
+    // Then
+    assertEquals(isAccepted, true);
   }
 
   /**
@@ -102,6 +102,25 @@ public class FileFilterTest extends TestCase {
     } catch (Exception ex) {
       Assert.fail("testAcceptWhenContain is FAILED because of an unhandled excaption");
     }
+  }
+
+  public void testAcceptWhenMimeTypeNullInContext() throws Exception {
+    // Given
+    FileFilter filter = new FileFilterDummy();
+    Map<String, Object> context = new HashMap<String, Object>();
+    context.put("mimeType", null);
+
+    List<String> mimetypes = new ArrayList<String>();
+    mimetypes.add("image/gif");
+    mimetypes.add("image/jpeg");
+    mimetypes.add("image/png");
+    ((FileFilterDummy) filter).setMimeTypes(mimetypes);
+
+    // When
+    boolean isAccepted = filter.accept(context);
+
+    // Then
+    assertEquals(isAccepted, false);
   }
   
   /**


### PR DESCRIPTION
When using the UI filter FileFilter to filter extensions based on the mimetype of the file, if the mimeType attribute in the context is null, it throws a NPE.
This fix returns false in such a case.