### PR TITLE
WIKI-1385 monospace and strike wiki syntax are not working

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -287,6 +287,7 @@ abstract public class HTMLSanitizer {
                                                                                                                                         "sup",
                                                                                                                                         "strike",
                                                                                                                                         "del",
+                                                                                                                                        "tt",
                                                                                                                                         "center",
                                                                                                                                         "blockquote",
                                                                                                                                         "hr",


### PR DESCRIPTION
- Enable <tt> element for monospace