### PR TITLE
PLF-8119 : Add JDK 11 support

### DIFF
--- a/commons-webui-ext/pom.xml
+++ b/commons-webui-ext/pom.xml
@@ -14,10 +14,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.core</groupId>
       <artifactId>exo.core.component.security.core</artifactId>
     </dependency>


### PR DESCRIPTION
JDK 11 does not bundle javax.activation:activation anymore so it must be included in PLF classpath and therefore not be excluded.