### PR TITLE
PLF-8608: define the fvh highlighter

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -213,10 +213,18 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
     esQuery.append("       \"post_tags\" : [\"</strong>\"],\n");
     esQuery.append("       \"fields\" : {\n");
     for (int i=0; i<this.searchFields.size(); i++) {
-      esQuery.append("         \""+searchFields.get(i)+"\" : {\n")
-              .append("          \"type\" : \"unified\",\n")
-              .append("          \"fragment_size\" : " + this.highlightFragmentSize + ",\n")
-              .append("          \"number_of_fragments\" : " + this.highlightFragmentNumber + "}");
+      if (!(searchFields.get(i)).equals("attachment.content")) {
+        esQuery.append("         \"" + searchFields.get(i) + "\" : {\n")
+                .append("          \"type\" : \"unified\",\n")
+                .append("          \"fragment_size\" : " + this.highlightFragmentSize + ",\n")
+                .append("          \"number_of_fragments\" : " + this.highlightFragmentNumber + "}");
+      }
+      if ((searchFields.get(i)).equals("attachment.content")) {
+        esQuery.append("         \"" + searchFields.get(i) + "\" : {\n")
+                .append("          \"type\" : \"fvh\",\n")
+                .append("          \"fragment_size\" : " + this.highlightFragmentSize + ",\n")
+                .append("          \"number_of_fragments\" : " + this.highlightFragmentNumber + "}");
+      }
       if (i<this.searchFields.size()-1) {
         esQuery.append(",");
       }


### PR DESCRIPTION
In order to increase the performance of highlighting in Elastic-search, we apply another highlighter` fvh` `Fast Vector highlighter ` to `attachment.content` which has a big size of content.